### PR TITLE
Add code block around build instruction command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Work in progress.
 
 To run, with Rust compiler and Cargo package manager installed:
 
-$ cargo run --release
+    cargo run --release
 
 When building on Windows, you may need to have MinGW gcc installed
 and in PATH for cargo to be able to build all the necessary


### PR DESCRIPTION
Remove `$` for easy copy and paste.